### PR TITLE
Add explainxkcd link to comic navigation

### DIFF
--- a/xkcd-enhancer/manifest.json
+++ b/xkcd-enhancer/manifest.json
@@ -1,6 +1,6 @@
 {
     "name":"xkcd Enhancer",
-    "version":"0.1.4",
+    "version":"0.1.5",
     "description":"Adds some minor enhancements to xkcd.com.",
     "author":"Spencer Harston",
     "icons":{
@@ -11,7 +11,7 @@
     },
     "content_scripts":[
         {
-            "run_at":"document_end",
+            "run_at":"document_idle",
             "matches": [
                 "https://xkcd.com/",
                 "https://xkcd.com/*/"

--- a/xkcd-enhancer/script.js
+++ b/xkcd-enhancer/script.js
@@ -33,6 +33,7 @@ async function getComicJson(url){
 // process the comic data
 function processComicJson(json){
     displayComicHoverText(json.alt);
+    addExplainLink(json.num);
 }
 
 // display the comic's hover text (title attribute) below the comic
@@ -43,6 +44,26 @@ function displayComicHoverText(hoverText){
     hoverTextElement.setAttribute('id', 'hoverText');
     hoverTextElement.appendChild(document.createTextNode(hoverText));
     comic.parentNode.insertBefore(hoverTextElement, comic.nextSibling);    
+}
+
+// add an explain link to the comic navigation
+function addExplainLink(comicNumber){
+    var explainURL = `https://www.explainxkcd.com/${comicNumber}/`;
+
+    var explainLink = document.createElement('a');
+    explainLink.href = explainURL;
+    explainLink.target = "_blank";
+    explainLink.accessKey = 'e';
+    explainLink.innerText = "Explain";
+    
+    var explainNav = document.createElement('li');
+    explainNav.append(explainLink);
+
+    var navs = document.querySelectorAll('.comicNav');
+
+    for (var nav of navs) {
+        nav.insertBefore(explainNav.cloneNode(true), nav.children[3]);
+    }
 }
 
 // call functions


### PR DESCRIPTION
This adds a link in the comic's navigation to explainxkcd.com/{comic_number}. 

For enhancement #3 